### PR TITLE
ci: speed up Nix release setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,19 +38,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
-      - name: Install Determinate Nix
+      - name: Install Nix
         if: ${{ steps.release-plz.outputs.prs_created == 'true' || steps.release-plz.outputs.releases_created == 'true' }}
-        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
-        with:
-          extra-conf: lazy-trees = true
-
-      - name: Set up FlakeHub Cache
-        if: ${{ steps.release-plz.outputs.prs_created == 'true' || steps.release-plz.outputs.releases_created == 'true' }}
-        uses: DeterminateSystems/flakehub-cache-action@77c6bddd7d747943530aaa578c57f233ee5d920e # v3.21.8
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
 
       - name: Enter Nix devshell
         if: ${{ steps.release-plz.outputs.prs_created == 'true' || steps.release-plz.outputs.releases_created == 'true' }}
         uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+        with:
+          arguments: .#ci-release
 
       - name: Bump changelog versions
         if: ${{ steps.release-plz.outputs.prs_created == 'true' }}

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,10 @@
       perSystem = { pkgs, config, inputs', system, lib, ... }: {
         formatter = pkgs.nixpkgs-fmt;
 
+        devShells.ci-release = pkgs.mkShell {
+          packages = [ inputs'.x52.packages.x52-release-tools ];
+        };
+
         devShells.default = pkgs.mkShell {
           packages = [
             config.formatter


### PR DESCRIPTION
## Summary

- install Nix with `nix-quick-install-action` on the Blacksmith release runner
- remove the FlakeHub cache from the release job
- keep `nix-develop` as a separate step
- add a focused `.#ci-release` shell containing only the x52 release tools
- keep the full default development shell unchanged

## Why

The latest Blacksmith release run spent most of its time setting up and uploading a cache for a very small Nix-backed operation:

| Step | Duration |
| --- | ---: |
| Install Determinate Nix | 31s |
| Set up FlakeHub Cache | 6s |
| Enter full dev shell | 16s |
| Bump changelog versions | 2s |
| FlakeHub Cache post-step | 2m35s |

The full release job took 4m19s. The Nix setup and cache teardown accounted for 3m28s.

This applies the setup already validated on Blacksmith in x52dev/confik: the pinned quick installer completed in 0–1s and the focused dev shell in 7s, without a cache post-step.

## Validation

- `nix develop .#ci-release -c command -v x52-bump-changelogs`
- `nix develop .#ci-release -c command -v x52-update-release-notes`
- `nix flake check --no-build --all-systems`

The release workflow runs only after pushes to `main`, so this PR cannot provide a direct after-change release timing before merge.
