### PR TITLE
ci: add zizmor security lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,17 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
   - package-ecosystem: nix
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
   - package-ecosystem: cargo
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,17 @@ jobs:
 
       - name: CI cache clean
         run: cargo-ci-cache-clean
+
+  zizmor:
+    name: GitHub Actions Security
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          advanced-security: false
+          annotations: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,7 @@ on:
   push:
     branches: [main]
 
-permissions:
-  attestations: write
-  contents: write
-  id-token: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release:
@@ -18,11 +14,16 @@ jobs:
     outputs:
       releases: ${{ steps.release-plz.outputs.releases }}
       releases_created: ${{ steps.release-plz.outputs.releases_created }}
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
@@ -66,7 +67,8 @@ jobs:
         if: ${{ steps.release-plz.outputs.releases_created == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
-        run: x52-comment-release-pr '${{ steps.release-plz.outputs.releases }}' '${{ github.sha }}'
+          RELEASES_JSON: ${{ steps.release-plz.outputs.releases }}
+        run: x52-comment-release-pr "$RELEASES_JSON" "$GITHUB_SHA"
 
   upload-assets:
     name: Upload release assets
@@ -89,6 +91,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
 
     env:
       CARGO_INCREMENTAL: 0
@@ -103,6 +109,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.RELEASE_TAG }}
+          persist-credentials: false
 
       - name: Install nasm
         if: matrix.os == 'windows-latest'
@@ -143,9 +150,14 @@ jobs:
     needs:
       - release
       - upload-assets
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Nix
         uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
@@ -158,4 +170,5 @@ jobs:
       - name: Comment on release PR
         env:
           GH_TOKEN: ${{ github.token }}
-        run: x52-comment-release-assets-uploaded '${{ needs.release.outputs.releases }}' '${{ github.sha }}'
+          RELEASES_JSON: ${{ needs.release.outputs.releases }}
+        run: x52-comment-release-assets-uploaded "$RELEASES_JSON" "$GITHUB_SHA"


### PR DESCRIPTION
Adds a pinned zizmor security-lint job to CI.

Also adds Dependabot cooldowns and scopes release permissions, checkout credentials, and release metadata handling.

Validation:

- `zizmor v1.29.0 --offline /workspace` — no findings to report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added automated security checks for GitHub Actions workflows.
  * Restricted release workflow permissions to only those required.
  * Improved handling of credentials and release metadata during publishing.

* **Chores**
  * Added a seven-day cooldown for automated dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->