### PR TITLE
ci: allow release comment job to view drafts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
       - release
       - upload-assets
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
 
     steps:


### PR DESCRIPTION
## Summary

- grant the final release comment job write access to repository contents

## Root cause

GitHub only includes draft releases in the releases list for callers with push access. The final comment job had only `contents: read`, so its API response omitted the draft release.

## Validation

- `nix develop -c just check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation permissions to support uploading release assets successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->