### PR TITLE
ci: update Homebrew tap after release

### DIFF
--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -1,0 +1,56 @@
+name: Update Homebrew tap
+
+on:
+  release:
+    types: [published]
+
+permissions: {}
+
+jobs:
+  update-homebrew-tap:
+    name: Update Homebrew tap
+    if: ${{ github.repository_owner == 'x52dev' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
+
+      - name: Enter Nix devshell
+        uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+        with:
+          arguments: .#ci-release
+
+      - name: Create Homebrew tap token
+        id: homebrew-tap-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.HOMEBREW_TAP_APP_CLIENT_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: x52dev
+          repositories: homebrew-tap
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Check out Homebrew tap
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: x52dev/homebrew-tap
+          token: ${{ steps.homebrew-tap-token.outputs.token }}
+          path: homebrew-tap
+          persist-credentials: true
+
+      - name: Update Homebrew tap
+        env:
+          GH_TOKEN: ${{ steps.homebrew-tap-token.outputs.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          X52_HOMEBREW_TAP_DIRECTORY: ${{ github.workspace }}/homebrew-tap
+        run: >-
+          x52-update-homebrew-tap --package protobug
+          --version "${RELEASE_TAG#protobug-v}" --tag "$RELEASE_TAG"

--- a/flake.lock
+++ b/flake.lock
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785613888,
-        "narHash": "sha256-lo8XxVBnpCURsONHb9ZLlYVLoEfBepWa6LMBCGnSudg=",
+        "lastModified": 1786328239,
+        "narHash": "sha256-ttcVfFssqTwMlrvLo4A8z0mMS7waHVyBV13hZ/cfdrM=",
         "owner": "x52dev",
         "repo": "nix",
-        "rev": "1ba39593f2d3dafc67ed0c390bbc0b51069fe586",
+        "rev": "4253f74552b9a5dca45ffc89b7d14f5ce7d629f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Adds a release-published workflow that creates a scoped x52dev/homebrew-tap App token and opens a formula-update PR after each release.

The workflow derives the version from protobug’s package-prefixed release tags. It also refreshes the x52dev/nix lock input because the prior revision did not provide x52-update-homebrew-tap.

Validated with actionlint and nix flake check path:.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Homebrew formula updates whenever a new release is published.
  * Homebrew users can now install the latest release through the tap without manual formula updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->